### PR TITLE
Fix handle leak

### DIFF
--- a/ntfsutils/fs.py
+++ b/ntfsutils/fs.py
@@ -95,6 +95,7 @@ def getfileinfo(path):
         raise WinError()
     info = BY_HANDLE_FILE_INFORMATION()
     rv = GetFileInformationByHandle(hfile, info)
+    CloseHandle(hfile)
     if rv == 0:
         raise WinError()
     return info


### PR DESCRIPTION
Need to close handle, otherwise you're left with dangling open files.
Found this after calling ntfsutils.hardlinks.samefile()
