### PR TITLE
Add missing LICENSE file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include CONTRIBUTORS.txt
 include CHANGES.txt
 include README.rst
+include LICENSE


### PR DESCRIPTION
It was missing hence not included in the build.
Thanks for this life saving tool!
