### PR TITLE
Support symbolic link + add unit tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,3 +2,4 @@
 - Roman Lacko [rlacko]
 - Barry Pederson [barryp]
 - Philippe Ombredanne [pombredanne]
+- Yu Byunghoo [if1live]

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ntfsutils
 =========
 
-A Python module to manipulate NTFS `hard links`_ and `junctions`_.
+A Python module to manipulate NTFS `hard links`_ and `junctions`_ and `symbolic links`_.
 
 Requirements
 ------------
@@ -19,4 +19,5 @@ See the LICENSE file for details.
 
 .. _hard links: https://en.wikipedia.org/wiki/Hard_link
 .. _junctions: https://en.wikipedia.org/wiki/NTFS_junction_point
+.. _symbolic links: http://en.wikipedia.org/wiki/NTFS_symbolic_link
 .. _ctypes: http://docs.python.org/library/ctypes.html

--- a/ntfsutils/fs.py
+++ b/ntfsutils/fs.py
@@ -45,6 +45,12 @@ class BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
                 ("nNumberOfLinks", DWORD),
                 ("nFileIndexHigh", DWORD),
                 ("nFileIndexLow", DWORD)]
+                
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms679360
+# for debugging
+GetLastError = ctypes.windll.kernel32.GetLastError
+GetLastError.argtypes = []
+GetLastError.restype = DWORD
 
 # http://msdn.microsoft.com/en-us/library/windows/desktop/aa363858
 CreateFile = ctypes.windll.kernel32.CreateFileW
@@ -84,6 +90,12 @@ DeviceIoControl.restype = BOOL
 CloseHandle = ctypes.windll.kernel32.CloseHandle
 CloseHandle.argtypes = [HANDLE]
 CloseHandle.restype = BOOL
+
+# http://msdn.microsoft.com/en-us/library/windows/desktop/aa363866
+CreateSymbolicLink = ctypes.windll.kernel32.CreateSymbolicLinkW
+CreateSymbolicLink.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, DWORD)
+CreateSymbolicLink.restype = BOOL
+
 
 def getfileinfo(path):
     """

--- a/ntfsutils/hardlink.py
+++ b/ntfsutils/hardlink.py
@@ -6,7 +6,7 @@
 
 __all__ = ["create", "samefile"]
 
-import fs
+from . import fs
 import ctypes
 from ctypes import WinError
 from ctypes.wintypes import BOOL

--- a/ntfsutils/junction.py
+++ b/ntfsutils/junction.py
@@ -8,14 +8,15 @@
 __all__ = ["create", "readlink", "unlink", "isjunction"]
 
 import os
-import fs
-from fs import CreateFile, GetFileAttributes, DeviceIoControl, CloseHandle
+from . import fs
+from .fs import CreateFile, GetFileAttributes, DeviceIoControl, CloseHandle
 
 import ctypes
 from ctypes import WinError, sizeof, byref
 from ctypes.wintypes import DWORD
 
 IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+IO_REPARSE_TAG_SYMLINK = 0xA000000C
 
 FSCTL_SET_REPARSE_POINT    = 0x000900A4
 FSCTL_GET_REPARSE_POINT    = 0x000900A8
@@ -58,18 +59,35 @@ def new_junction_reparse_buffer(path=None):
                     ("SubstituteNameLength", ctypes.c_ushort),
                     ("PrintNameOffset", ctypes.c_ushort),
                     ("PrintNameLength", ctypes.c_ushort),
-                    ("SubstituteNameBuffer", ctypes.c_wchar * substnamebufferchars),
+                    ("SubstituteNameBuffer", ctypes.c_ushort * substnamebufferchars),
                     ("PrintNameBuffer", ctypes.c_wchar * 1)]
+                    
+        def buffer_to_string(self, buf):
+            readable_name_buffer = [chr(x) for x in buf]
+            readable_name = "".join(readable_name_buffer)
+            return readable_name.rstrip("\0")
+        
+        @property
+        def readable_PrintNameBuffer(self):
+            return self.buffer_to_string(self.PrintNameBuffer)
+        
+        @property    
+        def readable_SubstituteNameBuffer(self):
+            return self.buffer_to_string(self.SubstituteNameBuffer)
 
-    numpathbytes = (substnamebufferchars - 1) * sizeof(ctypes.c_wchar)
+    numpathbytes = (substnamebufferchars - 1) * sizeof(ctypes.c_ushort)
     # We can't really use sizeof on the struct because of packing issues.
     # Instead, calculate the size manually
-    buffersize = (numpathbytes + (sizeof(ctypes.c_wchar) * 2) + 
+    buffersize = (numpathbytes + (sizeof(ctypes.c_ushort) * 2) + 
         (sizeof(ctypes.c_ushort) * 4))
     if path is None:
         buffer = REPARSE_DATA_BUFFER()
         buffer.ReparseTag = IO_REPARSE_TAG_MOUNT_POINT
     else:
+        tmp = REPARSE_DATA_BUFFER()
+        for i, x in enumerate(path):
+            tmp.SubstituteNameBuffer[i] = ord(x);
+            
         buffer = REPARSE_DATA_BUFFER(
             IO_REPARSE_TAG_MOUNT_POINT,
             buffersize,
@@ -79,7 +97,7 @@ def new_junction_reparse_buffer(path=None):
             # substitute name offset, length
             numpathbytes + 2, 0,
             # print name
-            path,
+            tmp.SubstituteNameBuffer,
             # substitute name
             "")
 
@@ -157,6 +175,11 @@ def readlink(path):
     if not isjunction(path):
         raise Exception("%s does not exist or is not a junction" % path)
 
+    reparseinfo = readreparseinfo(path)
+    name_buffer = reparseinfo.readable_SubstituteNameBuffer
+    return unparsed_unconvert(name_buffer)
+
+def readreparseinfo(path):
     hlink = CreateFile(path, fs.GENERIC_READ, fs.FILE_SHARE_READ, None,
         fs.OPEN_EXISTING,
         fs.FILE_FLAG_OPEN_REPARSE_POINT | fs.FILE_FLAG_BACKUP_SEMANTICS,
@@ -180,7 +203,7 @@ def readlink(path):
         if res == 0:
             raise WinError()
 
-        return unparsed_unconvert(junctioninfo.SubstituteNameBuffer)
+        return junctioninfo
     finally:
         CloseHandle(hlink)
 
@@ -190,3 +213,22 @@ def unlink(path):
         raise Exception("%s does not exist or is not a junction" % path)
     # Just get rid of the directory
     os.rmdir(path)
+
+def showreparseinfo(reparseinfo):            
+    keys = [
+        "ReparseTag",
+        "ReparseDataLength",
+        "Reserved",
+        "SubstituteNameOffset",
+        "SubstituteNameLength",
+        "PrintNameOffset",
+        "PrintNameLength",
+    ]
+    for key in keys:
+        val = getattr(reparseinfo, key)
+        print("%s\t:%s" % (key, str(val)))
+
+    extra_keys = ["readable_PrintNameBuffer", "readable_SubstituteNameBuffer"]
+    for key in extra_keys:
+        val = getattr(reparseinfo, key)
+        print("%s\t:%s" % (key, str(val)))

--- a/ntfsutils/symboliclink.py
+++ b/ntfsutils/symboliclink.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2012, the Mozilla Foundation. All rights reserved.
+# Use of this source code is governed by the Simplified BSD License which can
+# be found in the LICENSE file.
+
+# Library to deal with symbolic links
+
+__all__ = ["create"]
+
+import os
+from . import fs
+from .fs import CreateSymbolicLink
+
+import ctypes
+from ctypes import WinError
+
+def create(source, link_name):
+    """
+    Create a symbolic link at link_name pointing to source.
+    Need administrator permission to create a symbolic link.
+
+    http://stackoverflow.com/questions/6260149/os-symlink-support-in-windows
+    """
+    if not os.path.exists(source):
+        raise Exception("%s: source is not exists." % source)
+    if os.path.exists(link_name):
+        raise Exception("%s: symbolic link name already exists" % link_name)
+
+    flags = 1 if os.path.isdir(source) else 0
+    res = CreateSymbolicLink(link_name, source, flags)
+    if res == 0:
+        raise WinError()

--- a/tests/data/data.txt
+++ b/tests/data/data.txt
@@ -1,0 +1,1 @@
+ntfsutils

--- a/tests/hardlink_tests.py
+++ b/tests/hardlink_tests.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import unittest
+
+from ntfsutils import hardlink
+
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+
+class hardlink_success_Test(unittest.TestCase):
+    def setUp(self):
+        self.source = os.path.join(BASE_PATH, "data", "data.txt")
+        self.link_name = os.path.join(BASE_PATH, "data", "data-hardlink.txt")
+        
+    def tearDown(self):
+        try:
+            os.remove(self.link_name)
+        except OSError:
+            pass
+    
+    def test_run(self):
+        hardlink.create(self.source, self.link_name)
+        self.assertTrue(hardlink.samefile(self.source, self.link_name))

--- a/tests/junction_tests.py
+++ b/tests/junction_tests.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import unittest
+
+from ntfsutils import junction
+
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+
+class create_Test(unittest.TestCase):
+    def setUp(self):
+        self.source = os.path.join(BASE_PATH, "data")
+        self.link_name = os.path.join(BASE_PATH, "data-junction")
+        
+    def tearDown(self):
+        try:
+            os.removedirs(self.link_name)
+        except OSError:
+            pass
+        
+    def test_for_directory(self):
+        junction.create(self.source, self.link_name)
+        self.assertTrue(os.path.exists(self.link_name))
+        
+    def test_isjunction_success(self):
+        junction.create(self.source, self.link_name)
+        self.assertEqual(junction.isjunction(self.link_name), True)
+    
+    def test_isjunction_fail(self):
+        self.assertEqual(junction.isjunction(self.source), False)
+
+    def test_readlink(self):
+        junction.create(self.source, self.link_name)
+        self.assertEqual(junction.readlink(self.link_name), self.source)

--- a/tests/symboliclink_tests.py
+++ b/tests/symboliclink_tests.py
@@ -1,0 +1,52 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import unittest
+
+from ntfsutils import symboliclink
+
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+
+class create_for_dir_Test(unittest.TestCase):
+    def setUp(self):
+        self.source = os.path.join(BASE_PATH, 'data')
+        self.link_name =  os.path.join(BASE_PATH, 'tmp-data')
+        
+    def tearDown(self):
+        try:
+            os.removedirs(self.link_name)
+        except OSError:
+            pass
+    
+    def test_run(self):
+        symboliclink.create(self.source, self.link_name)        
+        self.assertEqual(True, os.path.isdir(self.link_name))
+
+            
+class create_for_file_Test(unittest.TestCase):
+    def setUp(self):
+        self.source = os.path.join(BASE_PATH, 'data', 'data.txt')
+        self.invalid_source = os.path.join(BASE_PATH, 'not-exist')
+        self.link_name =  os.path.join(BASE_PATH, 'data', 'tmp-data.txt')
+    
+    def tearDown(self):
+        try:
+            os.remove(self.link_name)
+        except OSError:
+            pass
+        
+    def test_source_not_exist(self):
+        with self.assertRaises(Exception) as cm:
+            symboliclink.create(self.invalid_source, self.link_name)
+            
+    def assertEqualFile(self, filepath_a, filepath_b):
+        with open(filepath_a, "rb") as f:
+            content_a = f.read()
+        with open(filepath_b, "rb") as f:
+            content_b = f.read()
+        self.assertEqual(content_a, content_b)
+            
+    def test_create(self):
+        symboliclink.create(self.source, self.link_name)
+        self.assertEqualFile(self.source, self.link_name)


### PR DESCRIPTION
* support symbolic link (CreateSymbolicLink based)
* add unit tests (hard link, junction, symbolic link)
* add GetLastError function (for debugging)
* add `showreparseinfo(reparseinfo)` to debugging reparse data buffer.
* extract method `readreparseinfo()` from `junction.create()`
  * to read symbolic link's reparse data buffer


