### PR TITLE
setup: remove use_2to3 option, no longer supported by setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ long_description = (
 install_requires=['setuptools']
 
 extra = {}
-if sys.version_info >= (3,):
-    extra['use_2to3'] = True
 
 setup(name='ntfsutils',
       version=version,


### PR DESCRIPTION
not required either
